### PR TITLE
Reformat for Terraform Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Modular Global HTTP Load Balancer for GCE using forwarding rules.
 
 ```ruby
 module "gce-lb-http" {
-  source            = "github.com/GoogleCloudPlatform/terraform-google-lb-http"
+  source            = "GoogleCloudPlatform/lb-http/google"
   name              = "group-http-lb"
   target_tags       = ["${module.mig1.target_tags}", "${module.mig2.target_tags}"]
   backends          = {
@@ -22,30 +22,7 @@ module "gce-lb-http" {
 }
 ```
 
-### Input variables
-
-- `region` (optional): Region for cloud resources. Default is `us-central1`.
-- `network` (optional): Name of the network to create resources in. Default is `default`.
-- `name` (required): Name for the forwarding rule and prefix for supporting resources.
-- `target_tags` (required) List of target tags for health check firewall rule.
-- `backends` (required): Map backend indices to list of [backend maps](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html#backend).
-- `backend_params` (required): Comma-separated encoded list of parameters in order: health check path, service port name, service port, backend timeout seconds.
-- `create_url_map` (optional): Set to `false` if url_map variable is provided. Default is `true`.
-- `url_map` (optional): The url_map resource to use. Default is to send all traffic to first backend.
-- `ssl` (optional): Set to `true` to enable SSL support and create a second forwarding rule for HTTPS traffic, requires variables `private_key` and `certificate`. Default is `false`.
-- `private_key` (optional): Content of the private SSL key. Required if ssl is `true`.
-- `certificate` (optional): Content of the SSL certificate. Required if ssl is `true`.
-
-### Output variables
-
-- `backend_services`: The backend service resources.
-- `external_ip`: The external IP assigned to the global fowarding rule.
-
 ## Resources created
-
-**Figure 1.** *diagram of terraform resources*
-
-![architecture diagram](./diagram.png)
 
 - [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
 - [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.


### PR DESCRIPTION
Hi there,

renamed the path of the source to the module registry instead of the GitHub repo

removed variables because all variable information is sourced from the variable and output files.

removed figure diagram because the Terraform Registry cannot render the image

If you can merge this into master and then add another release/tag so that the module registry will update. After that we'll be able to verify this module. 

Thanks 
Chris