### PR TITLE
fix failure when no backend specified (#8)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,6 @@ resource "google_compute_firewall" "default-hc" {
 
   allow {
     protocol = "tcp"
-    ports    = ["${element(split(",", element(var.backend_params, count.index)), 2)}"]
+    ports    = ["${element(split(",", element(split("|", join("", list(join("|", var.backend_params), replace(format("%*s", length(var.backend_params), ""), " ", "|")))), count.index)), 2)}"]
   }
 }


### PR DESCRIPTION
This change sets the `ports` list to [""] when `backend_params` is empty.

Ideally this would be done with an expression like:
```
"${length(var.backend_params) == 0 ? "" : element(split(",", element(var.backend_params, count.index)), 2)}"
```

But because of a limitation with HCL, it cannot be done and we've resorted
to the trick described in this issue:

https://github.com/hashicorp/hil/issues/50#issuecomment-320078816

The pipe `|` delimiter is used because it is not valid to use in GCP names.

Contributed according to the Google CLA.