### PR TITLE
Enable the replacement of `private_key` and `certificate` (#21)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,9 +60,12 @@ resource "google_compute_target_https_proxy" "default" {
 resource "google_compute_ssl_certificate" "default" {
   project     = "${var.project}"
   count       = "${(var.ssl && !var.use_ssl_certificates) ? 1 : 0}"
-  name        = "${var.name}-certificate"
+  name_prefix = "${var.name}-certificate-"
   private_key = "${var.private_key}"
   certificate = "${var.certificate}"
+  lifecycle   = {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_url_map" "default" {


### PR DESCRIPTION
Since `google_compute_ssl_certificate` cannot be updated after creation,
attempting to modify the `private_key` or `certificate` of the `google-lb-http`
will fail.  That is because the generated certificate cannot be
destroyed/created (to affect the change) while bound to its `target_https_proxy`.

By using `name_prefix` instead of `name`, a new certificate is generated
and attached to the `target_https_proxy`.

The `create_before_destroy` ensures that a certificate remains attached
to the `target_https_proxy` through the plan's application.

This does have a "breaking change" in that the SSL certificate name
is now computed rather than hard-coded.