### PR TITLE
Add security_policy support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,14 +76,14 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  project       = "${var.project}"
-  count         = "${length(var.backend_params)}"
-  name          = "${var.name}-backend-${count.index}"
-  port_name     = "${element(split(",", element(var.backend_params, count.index)), 1)}"
-  protocol      = "HTTP"
-  timeout_sec   = "${element(split(",", element(var.backend_params, count.index)), 3)}"
-  backend       = ["${var.backends["${count.index}"]}"]
-  health_checks = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
+  project         = "${var.project}"
+  count           = "${length(var.backend_params)}"
+  name            = "${var.name}-backend-${count.index}"
+  port_name       = "${element(split(",", element(var.backend_params, count.index)), 1)}"
+  protocol        = "HTTP"
+  timeout_sec     = "${element(split(",", element(var.backend_params, count.index)), 3)}"
+  backend         = ["${var.backends["${count.index}"]}"]
+  health_checks   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
   security_policy = "${var.security_policy}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "google_compute_backend_service" "default" {
   timeout_sec   = "${element(split(",", element(var.backend_params, count.index)), 3)}"
   backend       = ["${var.backends["${count.index}"]}"]
   health_checks = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
+  security_policy = "${var.security_policy}"
 }
 
 resource "google_compute_http_health_check" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,6 @@ variable ssl_certificates {
 }
 
 variable security_policy {
-  type        = "string"
   description = "The resource URL for the security policy to associate with the backend service"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,9 @@ variable ssl_certificates {
   description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   default     = []
 }
+
+variable security_policy {
+  type        = "string"
+  description = "The resource URL for the security policy to associate with the backend service"
+  default     = ""
+}


### PR DESCRIPTION
This adds the ability to pass a self_link of a [google_compute_security_policy](https://www.terraform.io/docs/providers/google/r/compute_security_policy.html) to be attached to the `backend_service` that this module manages.

Note that `google_compute_security_policy` is in beta. I wasn't sure if that blocks adding support for it. In testing, this worked as expected:

Usage:
* Assuming the `compute_security_policy` from the compute_security_policy [documentation](https://www.terraform.io/docs/providers/google/r/compute_security_policy.html):
```
resource "google_compute_security_policy" "policy" {
  name = "my-policy"

  rule {
    action   = "deny(403)"
    priority = "1000"
    match {
      versioned_expr = "SRC_IPS_V1"
      config {
        src_ip_ranges = ["9.9.9.9/32"]
      }
    }
    description = "Deny access to IPs in 9.9.9.0/24"
  }

  rule {
    action   = "allow"
    priority = "2147483647"
    match {
      versioned_expr = "SRC_IPS_V1"
      config {
        src_ip_ranges = ["*"]
      }
    }
    description = "default rule"
  }
}
```

* The module can then specify `security_policy`:

```
module "gce-lb-http" {
...
  security_policy = "${google_compute_security_policy.policy.self_link}"
}
```