### PR TITLE
adding cdn activation option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ resource "google_compute_backend_service" "default" {
   backend         = ["${var.backends["${count.index}"]}"]
   health_checks   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
   security_policy = "${var.security_policy}"
+  enable_cdn      = "${var.cdn}"
 }
 
 resource "google_compute_http_health_check" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,8 @@ variable security_policy {
   description = "The resource URL for the security policy to associate with the backend service"
   default     = ""
 }
+
+variable cdn {
+  description = "Set to `true` to enable cdn on backend."
+  default     = "false"
+}


### PR DESCRIPTION
Adding variable CDN with default value false and add the enable_cdn option in the google_compute_backend_service.