### PR TITLE
Better support for Shared VPC (example and firewall rules)

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 **/.terraform
 **/terraform.tfstate*
+**/terraform.tfvars

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -1,0 +1,61 @@
+# Shared VPC Example
+
+This example shows how to use this module in a Shared VPC setup. In a service project, it creates a global HTTP forwarding rule to forward traffic to an instance group. Meanwhile it ensures the host project has firewall rules in place to allow the health check ingress.
+
+## Set up the environment
+
+```
+gcloud auth application-default login
+export GOOGLE_PROJECT=$(gcloud config get-value project)
+```
+
+## Run Terraform
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+Open URL of load balancer in browser:
+
+```
+EXTERNAL_IP=$(terraform output -module gce-lb-http external_ip)
+(until curl -sf -o /dev/null http://${EXTERNAL_IP}; do echo "Waiting for Load Balancer... "; sleep 5 ; done) && open http://${EXTERNAL_IP}
+```
+
+> Wait for all instance to become healthy per output of: `gcloud compute backend-services get-health group-http-lb-backend-0 --global`
+
+You should see the instance details from the region closest to you.
+
+### Test balancing to other region
+
+Resize the instance group of your closest region to cause traffic to flow to the other group.
+
+If you are getting traffic from `group1` (us-west1) from `http://${EXTERNAL_IP}`, scale group 1 to 0 instances:
+
+```
+TF_VAR_group1_size=0 terraform apply
+```
+
+Otherwise scale group 2 (us-east1) to 0 instances:
+
+```
+TF_VAR_group2_size=0 terraform apply
+```
+
+Open the external IP again and verify you see traffic from the other group:
+
+```
+open http://${EXTERNAL_IP}
+```
+
+> It may take several minutes for the global load balancer to be created and the backends to register.
+
+## Cleanup
+
+Remove all resources created by terraform:
+
+```
+terraform destroy
+```

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -2,14 +2,24 @@
 
 This example shows how to use this module in a Shared VPC setup. In a service project, it creates a global HTTP forwarding rule to forward traffic to an instance group. Meanwhile it ensures the host project has firewall rules in place to allow the health check ingress.
 
-## Set up the environment
+## Usage
+
+### Configure the module
+
+To connect your load balancer to a Shared VPC, you need to edit some inputs to match your environment. Copy `example.tfvars` into `terraform.tfvars` and update the [inputs](#inputs) to specify your desired Shared VPC network.
+
+```
+cp example.tfvars terraform.tfvars
+vi terraform.tfvars
+```
+
+### Authenticate Terraform
 
 ```
 gcloud auth application-default login
-export GOOGLE_PROJECT=$(gcloud config get-value project)
 ```
 
-## Run Terraform
+### Run Terraform
 
 ```
 terraform init
@@ -20,42 +30,39 @@ terraform apply
 Open URL of load balancer in browser:
 
 ```
-EXTERNAL_IP=$(terraform output -module gce-lb-http external_ip)
-(until curl -sf -o /dev/null http://${EXTERNAL_IP}; do echo "Waiting for Load Balancer... "; sleep 5 ; done) && open http://${EXTERNAL_IP}
+EXTERNAL_IP=$(terraform output external_ip)
+(until curl -sf -o /dev/null $EXTERNAL_IP; do echo "Waiting for Load Balancer... "; sleep 5; done) && open http://$EXTERNAL_IP
 ```
 
-> Wait for all instance to become healthy per output of: `gcloud compute backend-services get-health group-http-lb-backend-0 --global`
-
-You should see the instance details from the region closest to you.
-
-### Test balancing to other region
-
-Resize the instance group of your closest region to cause traffic to flow to the other group.
-
-If you are getting traffic from `group1` (us-west1) from `http://${EXTERNAL_IP}`, scale group 1 to 0 instances:
+> Wait for all instance to become healthy per output of:
 
 ```
-TF_VAR_group1_size=0 terraform apply
+gcloud compute backend-services get-health group-http-lb-backend-0 --global --project=$(terraform output service_project)
 ```
 
-Otherwise scale group 2 (us-east1) to 0 instances:
-
-```
-TF_VAR_group2_size=0 terraform apply
-```
-
-Open the external IP again and verify you see traffic from the other group:
-
-```
-open http://${EXTERNAL_IP}
-```
-
-> It may take several minutes for the global load balancer to be created and the backends to register.
-
-## Cleanup
+### Cleanup
 
 Remove all resources created by terraform:
 
 ```
 terraform destroy
 ```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| group_size | Size of managed instance group to create | string | `2` | no |
+| host_project | ID for the Shared VPC host project | string | - | yes |
+| network | ID of network to launch instances on | string | - | yes |
+| region |  | string | `us-central1` | no |
+| service_account_email | The email of the service account for the MIG instance template. | string | `default` | no |
+| service_project | ID for the Shared VPC service project where instances will be deployed | string | - | yes |
+| subnetwork | ID of subnetwork to launch instances on | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external_ip | The external IP assigned to the load balancer. |
+| service_project | The service project the load balancer is in. |

--- a/examples/shared-vpc/example.tfvars
+++ b/examples/shared-vpc/example.tfvars
@@ -1,0 +1,9 @@
+host_project = "my-host-project-id"
+service_project = "my-service-project-id"
+network = "my-network-name"
+subnetwork = "my-subnetwork-name"
+
+# Leave uncommented to use defaults:
+# region = "us-central1"
+# group_size = "2"
+# service_account_email = "default"

--- a/examples/shared-vpc/gceme.sh.tpl
+++ b/examples/shared-vpc/gceme.sh.tpl
@@ -1,0 +1,109 @@
+#!/bin/bash -xe
+
+apt-get update
+apt-get install -y apache2 libapache2-mod-php
+
+cat > /var/www/html/index.php <<'EOF'
+<?php
+function metadata_value($value) {
+    $opts = [
+        "http" => [
+            "method" => "GET",
+            "header" => "Metadata-Flavor: Google"
+        ]
+    ];
+    $context = stream_context_create($opts);
+    $content = file_get_contents("http://metadata/computeMetadata/v1/$value", false, $context);
+    return $content;
+}
+?>
+
+<!doctype html>
+<html>
+<head>
+<!-- Compiled and minified CSS -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+
+<!-- Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/js/materialize.min.js"></script>
+<title>Frontend Web Server</title>
+</head>
+<body>
+<div class="container">
+<div class="row">
+<div class="col s2">&nbsp;</div>
+<div class="col s8">
+
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Backend that serviced this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Name</td>
+	  <td><?php printf(metadata_value("instance/name")) ?></td>
+	</tr>
+	<tr>
+	  <td>ID</td>
+	  <td><?php printf(metadata_value("instance/id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Hostname</td>
+	  <td><?php printf(metadata_value("instance/hostname")) ?></td>
+	</tr>
+	<tr>
+	  <td>Zone</td>
+	  <td><?php printf(metadata_value("instance/zone")) ?></td>
+	</tr>
+    <tr>
+	  <td>Machine Type</td>
+	  <td><?php printf(metadata_value("instance/machine-type")) ?></td>
+	</tr>
+	<tr>
+	  <td>Project</td>
+	  <td><?php printf(metadata_value("project/project-id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Internal IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/ip")) ?></td>
+	</tr>
+	<tr>
+	  <td>External IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/access-configs/0/external-ip")) ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Proxy that handled this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Address</td>
+	  <td><?php printf($_SERVER["HTTP_HOST"]); ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+
+</div>
+</div>
+<div class="col s2">&nbsp;</div>
+</div>
+</div>
+</html>
+EOF
+sudo mv /var/www/html/index.html /var/www/html/index.html.old
+
+[[ -n "${PROXY_PATH}" ]] && mkdir -p /var/www/html/${PROXY_PATH} && cp /var/www/html/index.php /var/www/html/${PROXY_PATH}/index.php
+
+systemctl enable apache2
+systemctl restart apache2

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider google {
+  region  = "${var.region}"
+  project = "${var.service_project}"
+}
+
+module "gce-lb-http" {
+  source            = "../../"
+  name              = "group-http-lb"
+  project           = "${var.service_project}"
+  target_tags       = ["${module.mig1.target_tags}"]
+  firewall_projects = ["${var.host_project}"]
+  firewall_networks = ["${var.network}"]
+
+  backends = {
+    "0" = [
+      {
+        group = "${module.mig1.instance_group}"
+      },
+    ]
+  }
+
+  backend_params = [
+    // health check path, port name, port number, timeout seconds.
+    "/,http,80,10",
+  ]
+}

--- a/examples/shared-vpc/mig.tf
+++ b/examples/shared-vpc/mig.tf
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "template_file" "group-startup-script" {
+  template = "${file("${format("%s/gceme.sh.tpl", path.module)}")}"
+
+  vars {
+    PROXY_PATH = ""
+  }
+}
+
+module "mig1" {
+  source                = "GoogleCloudPlatform/managed-instance-group/google"
+  version               = "1.1.13"
+  region                = "${var.region}"
+  network               = "${var.network}"
+  subnetwork            = "${var.subnetwork}"
+  project               = "${var.service_project}"
+  subnetwork_project    = "${var.host_project}"
+  service_account_email = "${var.service_account_email}"
+  name                  = "group1"
+  size                  = "${var.group1_size}"
+  target_tags           = ["allow-group1"]
+  service_port          = 80
+  service_port_name     = "http"
+  startup_script        = "${data.template_file.group-startup-script.rendered}"
+}

--- a/examples/shared-vpc/mig.tf
+++ b/examples/shared-vpc/mig.tf
@@ -31,9 +31,9 @@ module "mig1" {
   project               = "${var.service_project}"
   subnetwork_project    = "${var.host_project}"
   service_account_email = "${var.service_account_email}"
-  name                  = "group1"
-  size                  = "${var.group1_size}"
-  target_tags           = ["allow-group1"]
+  name                  = "shared-vpc-mig"
+  size                  = "${var.group_size}"
+  target_tags           = ["allow-shared-vpc-mig"]
   service_port          = 80
   service_port_name     = "http"
   startup_script        = "${data.template_file.group-startup-script.rendered}"

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output external_ip {
+  description = "The external IP assigned to the load balancer."
+  value       = "${module.gce-lb-http.external_ip}"
+}
+
+output service_project {
+  description = "The service project the load balancer is in."
+  value       = "${var.service_project}"
+}

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -39,10 +39,7 @@ variable subnetwork {
   description = "ID of subnetwork to launch instances on"
 }
 
-variable group1_size {
-  default = "2"
-}
-
-variable group2_size {
-  default = "2"
+variable group_size {
+  default     = "2"
+  description = "Size of managed instance group to create"
 }

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 variable region {
   default = "us-central1"
 }

--- a/examples/shared-vpc/variables.tf
+++ b/examples/shared-vpc/variables.tf
@@ -1,0 +1,32 @@
+variable region {
+  default = "us-central1"
+}
+
+variable host_project {
+  description = "ID for the Shared VPC host project"
+}
+
+variable service_project {
+  description = "ID for the Shared VPC service project where instances will be deployed"
+}
+
+variable service_account_email {
+  description = "The email of the service account for the MIG instance template."
+  default     = "default"
+}
+
+variable network {
+  description = "ID of network to launch instances on"
+}
+
+variable subnetwork {
+  description = "ID of subnetwork to launch instances on"
+}
+
+variable group1_size {
+  default = "2"
+}
+
+variable group2_size {
+  default = "2"
+}

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_http_health_check" "default" {
 
 resource "google_compute_firewall" "default-hc" {
   count         = "${length(var.firewall_networks)}"
-  project       = "${var.project}"
+  project       = "${var.firewall_projects[0] == "default" ? var.project : element(var.firewall_projects, count.index)}"
   count         = "${length(var.backend_params)}"
   name          = "${var.name}-hc-${count.index}"
   network       = "${element(var.firewall_networks, count.index)}"

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable firewall_networks {
   default     = ["default"]
 }
 
+variable firewall_projects {
+  description = "Name of the networks to projects to firewall rules in"
+  type        = "list"
+  default     = ["default"]
+}
+
 variable name {
   description = "Name for the forwarding rule and prefix for supporting resources"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,13 +30,13 @@ variable ip_version {
 }
 
 variable firewall_networks {
-  description = "Name of the networks to create firewall rules in"
+  description = "Names of the networks to create firewall rules in"
   type        = "list"
   default     = ["default"]
 }
 
 variable firewall_projects {
-  description = "Name of the networks to projects to firewall rules in"
+  description = "Names of the projects to create firewall rules in"
   type        = "list"
   default     = ["default"]
 }


### PR DESCRIPTION
This PR improves support for using the module in a Shared VPC model, with instances in a service project and firewall rules in a host project.

- Introduces a `firewall_projects` variable for specifying the (host) projects to create firewall rules in
- Adds an example of working with the variables in a Shared VPC setup 