### PR TITLE
added possibility to give a specific host to health-check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,7 @@ resource "google_compute_http_health_check" "default" {
   name         = "${var.name}-backend-${count.index}"
   request_path = "${element(split(",", element(var.backend_params, count.index)), 0)}"
   port         = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  host         = "${var.host}"
 }
 
 # Create firewall rule for each backend in each network specified, uses mod behavior of element().

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable backend_params {
   type        = "list"
 }
 
+variable host {
+  description = "HTTP header containing the host to reach for the http check, leave blank to use default value"
+  type       = "string"
+  default    = ""
+}
+
 variable backend_protocol {
   description = "The protocol with which to talk to the backend service"
   default     = "HTTP"


### PR DESCRIPTION
Added the host variable to "google_compute_http_health_check" and the string variable host to the variable file.

This will allow the user to specify a host header during health_check.