### PR TITLE
adding attribute ssl_policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "google_compute_target_https_proxy" "default" {
   name             = "${var.name}-https-proxy"
   url_map          = "${element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)}"
   ssl_certificates = ["${compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link))}"]
+  ssl_policy       = "${var.ssl_policy}"
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,11 @@ variable ssl_certificates {
   default     = []
 }
 
+variable ssl_policy {
+  description = "A reference to the SslPolicy resource that will be associated with the TargetHttpsProxy resource"
+  default     = ""
+}
+
 variable security_policy {
   description = "The resource URL for the security policy to associate with the backend service"
   default     = ""


### PR DESCRIPTION
Adding ssl_policy attribute for resource google_compute_target_https_proxy, empty by default